### PR TITLE
feat: firestore에서 유저의 정보 가져오기

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -10,8 +10,13 @@ from utils.auth import (
     auth_form,
     check_authentication,
     get_current_user,
+    get_organized_user_profile,
+    get_user_preferences_summary,
+    get_user_profile_from_firestore,
+    get_user_ratings_summary,
     has_completed_onboarding,
     logout,
+    organize_user_profile_data,
 )
 from utils.firebase_logger import get_firebase_logger
 from utils.pages import PageManager
@@ -72,182 +77,612 @@ def ranking_page_fragment(page_manager: PageManager):
     page_manager.ranking_page()
 
 
+def get_onboarding_history(uid: str):
+    """온보딩 이력 조회 (개선된 버전)"""
+    logger = get_firebase_logger()
+
+    onboarding_info = {
+        "completed": False,
+        "completed_date": None,
+        "profile_created": False,
+        "profile_created_date": None,
+        "profile_data": None,
+        "taste_ratings_count": 0,
+    }
+
+    # 1. 직접 프로필 문서 확인
+    try:
+        raw_profile_data = get_user_profile_from_firestore(uid)
+        if raw_profile_data:
+            onboarding_info["profile_created"] = True
+            onboarding_info["profile_created_date"] = raw_profile_data.get("created_at")
+
+            # organize_user_profile_data 사용하여 데이터 정리
+            onboarding_info["profile_data"] = organize_user_profile_data(
+                raw_profile_data
+            )
+
+            # 평점 데이터에서 taste_ratings_count 계산
+            ratings = raw_profile_data.get("ratings", {})
+            onboarding_info["taste_ratings_count"] = len(
+                [r for r in ratings.values() if r > 0]
+            )
+    except Exception as e:
+        st.warning(f"프로필 데이터 조회 중 오류: {str(e)}")
+
+    # 2. 온보딩 완료 로그 확인
+    if logger.is_available():
+        try:
+            onboarding_logs = logger.get_user_logs(
+                uid, limit=10, collection_name="onboarding_logs"
+            )
+
+            for log in onboarding_logs:
+                log_type = log.get("type", "")
+                timestamp = log.get("timestamp", "")
+
+                if log_type == "onboarding_completed":
+                    onboarding_info["completed"] = True
+                    onboarding_info["completed_date"] = timestamp
+                    break  # 가장 최근 완료 로그만 사용
+        except Exception as e:
+            st.warning(f"온보딩 로그 조회 중 오류: {str(e)}")
+
+    return onboarding_info
+
+
+def get_location_history(uid: str):
+    """위치 변경 이력 조회"""
+    logger = get_firebase_logger()
+    if not logger.is_available():
+        return []
+
+    # 네비게이션 로그에서 위치 관련 정보 조회
+    nav_logs = logger.get_user_logs(uid, limit=20, collection_name="navigation_logs")
+
+    location_changes = []
+    for log in nav_logs:
+        log_type = log.get("type", "")
+        detail = log.get("detail", {})
+        timestamp = log.get("timestamp", "")
+
+        if log_type == "location_saved":
+            location_changes.append(
+                {
+                    "type": "위치 저장",
+                    "address": detail.get("address", "알 수 없음"),
+                    "coordinates": detail.get("coordinates", {}),
+                    "timestamp": timestamp,
+                }
+            )
+        elif log_type == "location_change":
+            location_changes.append(
+                {
+                    "type": "위치 변경",
+                    "from_page": detail.get("from_page", "알 수 없음"),
+                    "timestamp": timestamp,
+                }
+            )
+
+    return location_changes
+
+
+def get_restaurant_history(uid: str):
+    """클릭한 음식점 이력 조회"""
+    logger = get_firebase_logger()
+    if not logger.is_available():
+        return []
+
+    # 음식점 로그 조회
+    restaurant_logs = logger.get_user_logs(
+        uid, limit=50, collection_name="restaurant_logs"
+    )
+
+    restaurant_history = []
+    for log in restaurant_logs:
+        log_type = log.get("type", "")
+        detail = log.get("detail", {})
+        timestamp = log.get("timestamp", "")
+
+        if log_type == "restaurant_click":
+            restaurant_history.append(
+                {
+                    "type": "음식점 클릭",
+                    "restaurant_name": detail.get("restaurant_name", "알 수 없음"),
+                    "category": detail.get("category", ""),
+                    "location": detail.get("location", ""),
+                    "grade": detail.get("grade"),
+                    "from_page": detail.get("from_page", ""),
+                    "timestamp": timestamp,
+                    "url": detail.get("restaurant_url", ""),
+                }
+            )
+        elif log_type == "restaurant_detail_view":
+            restaurant_history.append(
+                {
+                    "type": "상세정보 조회",
+                    "restaurant_name": detail.get("restaurant_name", "알 수 없음"),
+                    "from_page": detail.get("from_page", ""),
+                    "timestamp": timestamp,
+                }
+            )
+
+    return restaurant_history
+
+
 @st.fragment
-def user_activity_logs_fragment():
-    """사용자 활동 로그 페이지 부분만 부분 재실행"""
+def my_page_fragment():
+    """마이페이지 부분만 부분 재실행"""
     st.session_state.fragment_runs += 1
 
-    st.title("📊 내 활동 로그")
+    st.title("👤 마이페이지")
 
-    logger = get_firebase_logger()
     user_info = get_current_user()
+    uid = user_info.get("localId")
+    if not user_info:
+        st.error("❌ 로그인이 필요합니다.")
+        return
 
-    if user_info and logger.is_available():
         uid = user_info.get("localId")
 
-        # 탭으로 구분
-        log_tab, stats_tab, collection_tab = st.tabs(
-            ["📝 최근 활동", "📈 통계", "📂 컬렉션별 로그"]
-        )
+    # 공통 데이터 미리 로드 (한 번만 조회하여 성능 개선)
+    user_profile = get_organized_user_profile(uid)
+    preferences = get_user_preferences_summary(uid)
+    ratings_summary = get_user_ratings_summary(uid)
+    restaurant_history = get_restaurant_history(uid)
+    location_history = get_location_history(uid)
+    onboarding_info = get_onboarding_history(uid)
 
-        with log_tab:
-            st.subheader("최근 활동 로그")
+    # 사용자 기본 정보 표시
+    st.header("👋 환영합니다!")
+    col1, col2, col3 = st.columns([2, 1, 1])
 
-            # 로그 개수 선택
-            log_limit = st.selectbox("표시할 로그 개수", [10, 20, 50, 100], index=0)
+    with col1:
+        st.info(f"📧 **이메일:** {user_info.get('email', '알 수 없음')}")
+        st.info(f"👤 **닉네임:** {user_info.get('displayName', '사용자')}")
 
-            logs = logger.get_user_logs(uid, limit=log_limit)
+    with col2:
+        # 가입일 표시 (metadata에서)
+        metadata = user_info.get("metadata", {})
+        if metadata.get("creationTime"):
+            from datetime import datetime
 
-            if logs:
-                for i, log in enumerate(logs):
-                    collection_name = log.get("collection", "unknown")
-                    activity_type = log.get("type", "Unknown")
-                    timestamp = log.get("timestamp", "No timestamp")
+            creation_time = datetime.fromtimestamp(metadata["creationTime"] / 1000)
+            st.metric("🗓️ 가입일", creation_time.strftime("%Y.%m.%d"))
 
-                    # 컬렉션별 이모지 추가
-                    collection_emoji = {
-                        "auth_logs": "🔐",
-                        "navigation_logs": "🧭",
-                        "search_logs": "🔍",
-                        "interaction_logs": "⚡",
-                        "restaurant_logs": "🍽️",
-                        "activity_logs": "📋",
-                        "onboarding_logs": "👤",
-                    }.get(collection_name, "📝")
+    with col3:
+        # 마지막 로그인 표시
+        if metadata.get("lastSignInTime"):
+            last_signin = datetime.fromtimestamp(metadata["lastSignInTime"] / 1000)
+            st.metric("🔐 마지막 로그인", last_signin.strftime("%m.%d %H:%M"))
 
-                    with st.expander(
-                        f"{collection_emoji} {i + 1}. [{collection_name}] {activity_type} - {timestamp}"
-                    ):
-                        st.json(log.get("detail", {}))
+    st.divider()
+
+    # 간단한 활동 요약 대시보드
+    st.subheader("📊 활동 요약")
+
+    # 요약 정보 조회
+    logger = get_firebase_logger()
+
+    if logger.is_available():
+        # 통계 정보 수집
+        stats = logger.get_user_statistics(uid)
+
+        # 메트릭 표시
+        col1, col2, col3, col4, col5 = st.columns(5)
+
+        with col1:
+            total_activities = stats.get("total_activities", 0) if stats else 0
+            st.metric("🎯 총 활동", f"{total_activities}회")
+
+        with col2:
+            rated_count = (
+                ratings_summary.get("total_rated", 0) if ratings_summary else 0
+            )
+            st.metric("⭐ 평가한 음식점", f"{rated_count}개")
+
+        with col3:
+            visited_count = len(restaurant_history) if restaurant_history else 0
+            st.metric("🍽️ 방문한 음식점", f"{visited_count}개")
+
+        with col4:
+            location_changes = len(location_history) if location_history else 0
+            st.metric("📍 위치 변경", f"{location_changes}회")
+
+        with col5:
+            avg_rating = (
+                ratings_summary.get("average_rating", 0) if ratings_summary else 0
+            )
+            if avg_rating > 0:
+                st.metric("🌟 평균 평점", f"{avg_rating:.1f}점")
             else:
-                st.info("아직 활동 로그가 없습니다.")
-                st.info("메인 페이지에서 활동을 해보세요!")
+                st.metric("🌟 평균 평점", "없음")
 
-        with collection_tab:
-            st.subheader("컬렉션별 로그 조회")
+    st.divider()
 
-            # 컬렉션 선택
-            collection_options = {
-                "전체": None,
-                "🔐 인증 로그": "auth_logs",
-                "🧭 네비게이션 로그": "navigation_logs",
-                "🔍 검색 로그": "search_logs",
-                "⚡ 상호작용 로그": "interaction_logs",
-                "🍽️ 음식점 로그": "restaurant_logs",
-                "👤 온보딩 로그": "onboarding_logs",
-                "📋 기타 활동 로그": "activity_logs",
-            }
+    # 탭으로 구분
+    profile_tab, rating_tab, onboarding_tab, location_tab, restaurant_tab = st.tabs(
+        ["🎯 내 취향", "⭐ 내 평점", "📝 온보딩 이력", "📍 위치 이력", "🍽️ 음식점 이력"]
+    )
 
-            selected_collection_display = st.selectbox(
-                "조회할 컬렉션 선택", list(collection_options.keys())
-            )
-            selected_collection = collection_options[selected_collection_display]
+    with profile_tab:
+        st.subheader("🎯 내 취향 프로필")
 
-            # 로그 개수 선택
-            collection_log_limit = st.selectbox(
-                "표시할 로그 개수",
-                [10, 20, 50, 100],
-                index=0,
-                key="collection_log_limit",
-            )
+        # 미리 로드된 데이터 사용
+        if user_profile and preferences:
+            # 기본 정보
+            col1, col2 = st.columns(2)
 
-            collection_logs = logger.get_user_logs(
-                uid, limit=collection_log_limit, collection_name=selected_collection
-            )
+            with col1:
+                st.markdown("### 📊 기본 정보")
+                basic_info = user_profile.get("basic_info", {})
+                if basic_info.get("age"):
+                    st.info(f"🎂 **나이:** {basic_info['age']}세")
+                if basic_info.get("gender"):
+                    st.info(f"👤 **성별:** {basic_info['gender']}")
 
-            if collection_logs:
-                st.info(f"총 {len(collection_logs)}개의 로그를 찾았습니다.")
+                # 예산 정보
+                budget_info = preferences.get("budget_range", {})
+                if budget_info.get("regular"):
+                    st.info(f"💰 **평상시 예산:** {budget_info['regular']}원")
+                if budget_info.get("special"):
+                    st.info(f"💎 **특별한 날 예산:** {budget_info['special']}원")
 
-                for i, log in enumerate(collection_logs):
-                    activity_type = log.get("type", "Unknown")
-                    timestamp = log.get("timestamp", "No timestamp")
-                    collection_name = log.get(
-                        "collection", selected_collection or "unknown"
-                    )
+            with col2:
+                st.markdown("### 🌶️ 식사 선호도")
+                if preferences.get("spice_level"):
+                    spice_emoji = {"안매움": "😊", "적당히": "🌶️", "매움": "🔥"}
+                    spice_level = preferences["spice_level"]
+                    emoji = spice_emoji.get(spice_level, "🌶️")
+                    st.info(f"{emoji} **맵기 선호도:** {spice_level}")
 
-                    with st.expander(f"{i + 1}. {activity_type} - {timestamp}"):
-                        col1, col2 = st.columns([1, 3])
-                        with col1:
-                            st.write(f"**컬렉션:** {collection_name}")
-                            st.write(f"**타입:** {activity_type}")
-                        with col2:
-                            st.json(log.get("detail", {}))
-            else:
-                st.info(f"{selected_collection_display}에 해당하는 로그가 없습니다.")
+                if preferences.get("dining_companions"):
+                    companions = ", ".join(preferences["dining_companions"])
+                    st.info(f"👥 **주로 함께 식사:** {companions}")
 
-        with stats_tab:
-            st.subheader("활동 통계")
+            # 선호 카테고리
+            st.markdown("### 🍜 선호하는 음식")
+            if preferences.get("food_preferences_large"):
+                categories = preferences["food_preferences_large"]
+                cols = st.columns(min(len(categories), 4))
+                for i, category in enumerate(categories):
+                    with cols[i % 4]:
+                        st.success(f"✨ {category}")
 
-            stats = logger.get_user_statistics(uid)
+            # 제한사항
+            restrictions = []
+            if preferences.get("dislikes"):
+                restrictions.extend(preferences["dislikes"])
+            if preferences.get("allergies"):
+                restrictions.extend(preferences["allergies"])
 
-            if stats:
-                # 전체 통계
-                col1, col2, col3 = st.columns(3)
+            if restrictions:
+                st.markdown("### 🚫 식사 제한사항")
+                restriction_cols = st.columns(min(len(restrictions), 3))
+                for i, restriction in enumerate(restrictions):
+                    with restriction_cols[i % 3]:
+                        st.error(f"❌ {restriction}")
 
-                with col1:
-                    st.metric("총 활동 수", stats.get("total_activities", 0))
+        else:
+            st.warning("⚠️ 프로필 정보가 없습니다. 온보딩을 다시 진행해보세요.")
 
-                with col2:
-                    most_active = stats.get("most_active_type", "없음")
-                    st.metric("가장 많은 활동", most_active)
+    with rating_tab:
+        st.subheader("⭐ 내가 평가한 음식점")
 
-                with col3:
-                    most_active_collection = stats.get("most_active_collection", "없음")
-                    st.metric("가장 활발한 영역", most_active_collection)
+        # 미리 로드된 데이터 사용
+        if ratings_summary and ratings_summary.get("total_rated", 0) > 0:
+            # 요약 통계
+            col1, col2, col3 = st.columns(3)
 
-                # 컬렉션별 통계
-                st.subheader("📂 영역별 활동 분포")
-                collection_stats = stats.get("collection_stats", {})
+            with col1:
+                st.metric("🍽️ 평가한 음식점", f"{ratings_summary['total_rated']}개")
 
-                if collection_stats:
+            with col2:
+                st.metric("⭐ 평균 평점", f"{ratings_summary['average_rating']:.1f}점")
+
+            with col3:
+                # 가장 많이 준 평점
+                distribution = ratings_summary["rating_distribution"]
+                if distribution:
+                    most_common = max(distribution.items(), key=lambda x: x[1])
+                    st.metric("🎯 선호 평점", f"{most_common[0]}점")
+
+            st.divider()
+
+            # 평점 분포 차트
+            st.markdown("### 📊 평점 분포")
+            if distribution:
+                try:
                     import pandas as pd
+                except ImportError:
+                    st.error("pandas 라이브러리가 필요합니다.")
+                    return
 
-                    # 컬렉션 이름을 한글로 변환
-                    collection_names = {
-                        "auth_logs": "🔐 인증",
-                        "navigation_logs": "🧭 네비게이션",
-                        "search_logs": "🔍 검색",
-                        "interaction_logs": "⚡ 상호작용",
-                        "restaurant_logs": "🍽️ 음식점",
-                        "activity_logs": "📋 기타",
-                    }
+                chart_data = pd.DataFrame(
+                    [
+                        {"평점": f"{star}⭐", "개수": count}
+                        for star, count in distribution.items()
+                        if count > 0
+                    ]
+                )
 
-                    collection_data = []
-                    for col_name, count in collection_stats.items():
-                        display_name = collection_names.get(col_name, col_name)
-                        collection_data.append([display_name, count])
+                if not chart_data.empty:
+                    st.bar_chart(chart_data.set_index("평점"))
 
-                    df_collections = pd.DataFrame(
-                        collection_data, columns=["영역", "활동 수"]
-                    )
-                    st.bar_chart(df_collections.set_index("영역"))
+            st.divider()
 
-                st.subheader("🎯 세부 활동 유형별 분포")
-                activity_types = stats.get("activity_types", {})
+            # 평가한 음식점 목록
+            st.markdown("### 🏪 평가한 음식점 목록")
+            rated_restaurants = ratings_summary.get("rated_restaurants", [])
 
-                if activity_types:
-                    # 바차트로 표시
-                    import pandas as pd
+            if rated_restaurants:
+                # 평점별로 필터링 옵션
+                all_ratings = sorted(
+                    set(r["rating"] for r in rated_restaurants), reverse=True
+                )
+                selected_rating = st.selectbox(
+                    "평점별 필터", ["전체"] + [f"{r}점" for r in all_ratings], index=0
+                )
 
-                    df = pd.DataFrame(
-                        list(activity_types.items()), columns=["활동 유형", "횟수"]
-                    )
-                    # 상위 10개만 표시
-                    df_top = df.nlargest(10, "횟수")
-                    st.bar_chart(df_top.set_index("활동 유형"))
-
-                    # 전체 활동 유형 표시
-                    with st.expander("전체 활동 유형 보기"):
-                        st.dataframe(
-                            df.sort_values("횟수", ascending=False),
-                            use_container_width=True,
-                        )
+                # 필터링
+                if selected_rating != "전체":
+                    target_rating = int(selected_rating.replace("점", ""))
+                    filtered_restaurants = [
+                        r for r in rated_restaurants if r["rating"] == target_rating
+                    ]
                 else:
-                    st.info("세부 통계 데이터가 없습니다.")
+                    filtered_restaurants = rated_restaurants
+
+                st.info(
+                    f"📊 {len(filtered_restaurants)}개 음식점 (총 {len(rated_restaurants)}개 중)"
+                )
+
+                # 음식점 목록 표시
+                for i, restaurant in enumerate(
+                    filtered_restaurants[:20]
+                ):  # 최대 20개까지 표시
+                    with st.container():
+                        col1, col2, col3 = st.columns([1, 3, 1])
+
+                        with col1:
+                            # 평점을 별로 표시
+                            rating = restaurant["rating"]
+                            stars = "⭐" * rating
+                            st.write(f"**{stars}**")
+                            st.caption(f"{rating}점")
+
+                        with col2:
+                            # diner_idx로 실제 음식점 정보 조회할 수 있지만,
+                            # 현재는 diner_idx만 있으므로 간단히 표시
+                            diner_idx = restaurant.get("diner_idx", "알 수 없음")
+                            st.write(f"**음식점 ID:** {diner_idx}")
+                            st.caption(
+                                "음식점 상세 정보는 온보딩에서 평가한 음식점입니다."
+                            )
+
+                        with col3:
+                            if restaurant.get("timestamp"):
+                                st.caption(f"평가일: {restaurant['timestamp']}")
+
+                        if i < len(filtered_restaurants) - 1:
+                            st.divider()
+
+                if len(filtered_restaurants) > 20:
+                    st.info(
+                        f"💡 {len(filtered_restaurants) - 20}개 음식점이 더 있습니다."
+                    )
+
             else:
-                st.info("통계 데이터를 불러올 수 없습니다.")
-    else:
-        st.error("로그 시스템을 사용할 수 없습니다.")
+                st.info("📝 아직 평가한 음식점이 없습니다.")
+
+        else:
+            st.info("⭐ 아직 평가한 음식점이 없습니다.")
+            st.markdown("""
+            **💡 음식점을 평가하는 방법:**
+            1. 온보딩에서 취향 평가하기
+            2. 추천받은 음식점에 평점 남기기
+            """)
+
+    with onboarding_tab:
+        st.subheader("📝 온보딩 완료 이력")
+
+        # 미리 로드된 데이터 사용
+        if onboarding_info:
+            # 상태 요약
+            col1, col2, col3 = st.columns(3)
+
+            with col1:
+                if onboarding_info["completed"]:
+                    st.success("✅ 온보딩 완료")
+                    if onboarding_info["completed_date"]:
+                        st.caption(f"완료일: {onboarding_info['completed_date']}")
+                else:
+                    st.error("❌ 온보딩 미완료")
+
+            with col2:
+                if onboarding_info["profile_created"]:
+                    st.success("✅ 프로필 생성 완료")
+                    if onboarding_info["profile_created_date"]:
+                        st.caption(f"생성일: {onboarding_info['profile_created_date']}")
+                else:
+                    st.warning("⚠️ 프로필 미생성")
+
+            with col3:
+                ratings_count = onboarding_info["taste_ratings_count"]
+                st.info(f"⭐ 취향 평가: {ratings_count}회")
+
+            # 프로필 데이터가 있으면 요약 정보 표시
+            if onboarding_info.get("profile_data"):
+                st.divider()
+                st.markdown("### 📋 프로필 요약")
+
+                profile_data = onboarding_info["profile_data"]
+                summary_col1, summary_col2 = st.columns(2)
+
+                with summary_col1:
+                    # 기본 정보
+                    basic_info = profile_data.get("basic_info", {})
+                    if basic_info.get("age") or basic_info.get("gender"):
+                        info_parts = []
+                        if basic_info.get("age"):
+                            info_parts.append(f"{basic_info['age']}세")
+                        if basic_info.get("gender"):
+                            info_parts.append(basic_info["gender"])
+                        st.info(f"👤 **기본 정보:** {' / '.join(info_parts)}")
+
+                    # 예산 정보
+                    budget_info = profile_data.get("budget_info", {})
+                    if budget_info.get("regular_budget") or budget_info.get(
+                        "special_budget"
+                    ):
+                        budget_parts = []
+                        if budget_info.get("regular_budget"):
+                            budget_parts.append(
+                                f"평상시: {budget_info['regular_budget']}"
+                            )
+                        if budget_info.get("special_budget"):
+                            budget_parts.append(
+                                f"특별한 날: {budget_info['special_budget']}"
+                            )
+                        st.info(f"💰 **예산:** {' / '.join(budget_parts)}")
+
+                with summary_col2:
+                    # 선호도 정보
+                    if profile_data.get("spice_level"):
+                        st.info(f"🌶️ **맵기 선호도:** {profile_data['spice_level']}")
+
+                    if profile_data.get("dining_companions"):
+                        companions = ", ".join(profile_data["dining_companions"][:3])
+                        if len(profile_data["dining_companions"]) > 3:
+                            companions += "..."
+                        st.info(f"👥 **식사 동반자:** {companions}")
+
+                # 선호 카테고리
+                if profile_data.get("food_preferences_large"):
+                    st.markdown("#### 🍜 선호 음식 카테고리")
+                    categories = profile_data["food_preferences_large"]
+                    category_cols = st.columns(min(len(categories), 4))
+                    for i, category in enumerate(categories):
+                        with category_cols[i % 4]:
+                            st.success(f"✨ {category}")
+
+            st.divider()
+
+            if not onboarding_info["completed"]:
+                st.warning("📝 온보딩을 완료하면 더 정확한 추천을 받을 수 있습니다!")
+
+                col1, col2 = st.columns([1, 3])
+                with col1:
+                    if st.button("🚀 온보딩 다시 하기"):
+                        # 온보딩 플래그 리셋
+                        st.session_state["force_onboarding"] = True
+                        st.rerun()
+                with col2:
+                    st.caption("⚠️ 기존 프로필 정보가 새로운 정보로 업데이트됩니다.")
+            else:
+                # 온보딩이 완료된 경우에도 재설정 옵션 제공
+                with st.expander("🔄 프로필 다시 설정하기"):
+                    st.warning(
+                        "⚠️ **주의:** 기존의 모든 프로필 정보가 삭제되고 새로 설정됩니다."
+                    )
+                    if st.button("✅ 프로필 재설정 확인", type="primary"):
+                        st.session_state["force_onboarding"] = True
+                        st.rerun()
+        else:
+            st.error("온보딩 정보를 불러올 수 없습니다.")
+
+    with location_tab:
+        st.subheader("📍 위치 변경 이력")
+
+        # 미리 로드된 데이터 사용
+        if location_history:
+            st.info(f"📍 총 {len(location_history)}번의 위치 관련 활동이 있습니다.")
+
+            for i, location in enumerate(location_history[:10]):  # 최근 10개만 표시
+                with st.container():
+                    col1, col2, col3 = st.columns([1, 3, 1])
+
+                    with col1:
+                        if location["type"] == "위치 저장":
+                            st.success("💾 저장")
+                        else:
+                            st.info("🔄 변경")
+
+                    with col2:
+                        if location["type"] == "위치 저장":
+                            st.write(f"**주소:** {location['address']}")
+                            coords = location.get("coordinates", {})
+                            if coords:
+                                st.caption(
+                                    f"좌표: {coords.get('lat', 0):.4f}, {coords.get('lon', 0):.4f}"
+                                )
+                        else:
+                            st.write(f"**페이지:** {location['from_page']}")
+
+                    with col3:
+                        if location["timestamp"]:
+                            st.caption(location["timestamp"])
+
+                    if i < len(location_history) - 1:
+                        st.divider()
+        else:
+            st.info("📍 아직 위치 변경 이력이 없습니다.")
+
+    with restaurant_tab:
+        st.subheader("🍽️ 방문한 음식점 이력")
+
+        # 미리 로드된 데이터 사용
+        if restaurant_history:
+            st.info(f"🍽️ 총 {len(restaurant_history)}개의 음식점과 상호작용했습니다.")
+
+            # 최근 방문한 음식점들을 카드 형태로 표시
+            for i, restaurant in enumerate(restaurant_history[:15]):  # 최근 15개만 표시
+                with st.container():
+                    col1, col2, col3, col4 = st.columns([1, 3, 1, 1])
+
+                    with col1:
+                        if restaurant["type"] == "음식점 클릭":
+                            st.success("👆 클릭")
+                        else:
+                            st.info("👀 상세보기")
+
+                    with col2:
+                        st.write(f"**{restaurant['restaurant_name']}**")
+                        details = []
+                        if restaurant.get("category"):
+                            details.append(restaurant["category"])
+                        if restaurant.get("location"):
+                            details.append(restaurant["location"])
+                        if details:
+                            st.caption(" | ".join(details))
+
+                        # 등급 표시
+                        if restaurant.get("grade"):
+                            grade = restaurant["grade"]
+                            stars = "⭐" * int(grade) if grade else ""
+                            st.caption(f"등급: {stars} ({grade}점)")
+
+                    with col3:
+                        if restaurant.get("from_page"):
+                            page_emoji = {"chat": "💬", "ranking": "🏆", "search": "🔍"}
+                            emoji = page_emoji.get(restaurant["from_page"], "📱")
+                            st.write(f"{emoji}")
+                            st.caption(restaurant["from_page"])
+
+                    with col4:
+                        if restaurant["timestamp"]:
+                            st.caption(restaurant["timestamp"])
+
+                        # 음식점 URL이 있으면 버튼 표시
+                        if restaurant.get("url"):
+                            st.link_button(
+                                "🔗", restaurant["url"], use_container_width=True
+                            )
+
+                    if i < len(restaurant_history) - 1:
+                        st.divider()
+        else:
+            st.info("🍽️ 아직 방문한 음식점이 없습니다. 맛집을 찾아보세요!")
 
 
 @st.fragment
@@ -279,25 +714,33 @@ def render_authenticated_sidebar():
         st.divider()
 
         # 페이지 선택
-        page_options = ["🤤 오늘 머먹?", "🕺🏽 니가 가본 그집", "📊 내 활동 로그", "⚽ 맛집 이상형 월드컵"]
-        
+        page_options = [
+            "🤤 오늘 머먹?",
+            "🕺🏽 니가 가본 그집",
+            "👤 마이페이지",
+            "⚽ 맛집 이상형 월드컵",
+        ]
+
         # 온보딩 완료 직후라면 chat_page를 기본값으로 설정
         default_index = 0  # 기본적으로 첫 번째 옵션 (chat_page)
-        
+
         # 온보딩 완료 직후 감지: 온보딩이 완료되었지만 아직 페이지 선택 기록이 없는 경우
         if "selected_page_history" not in st.session_state:
             st.session_state.selected_page_history = []
             # 온보딩을 막 완료한 사용자는 chat_page로 안내
             if has_completed_onboarding():
                 default_index = 0  # chat_page 인덱스
-        
+
         # 명시적인 온보딩 완료 플래그가 있는 경우
-        if "onboarding_just_completed" in st.session_state and st.session_state.onboarding_just_completed:
+        if (
+            "onboarding_just_completed" in st.session_state
+            and st.session_state.onboarding_just_completed
+        ):
             default_index = 0  # chat_page 인덱스
             st.session_state.onboarding_just_completed = False  # 플래그 리셋
-        
+
         selected_page = st.radio("페이지 선택", page_options, index=default_index)
-        
+
         # 페이지 선택 기록 추가
         if selected_page not in st.session_state.selected_page_history:
             st.session_state.selected_page_history.append(selected_page)
@@ -340,12 +783,20 @@ def main():
         login_page_fragment()
         return
 
-    # 첫 로그인 사용자이고 온보딩을 완료하지 않은 경우 온보딩 페이지 표시
-    # is_first_login() 첫 로그인에 온보딩을 마치지 않은 경우도 있기때문에 and 값 없앰
-    if not has_completed_onboarding():
+    # 첫 로그인 사용자이고 온보딩을 완료하지 않은 경우 또는 강제 온보딩 플래그가 있는 경우 온보딩 페이지 표시
+    force_onboarding = st.session_state.get("force_onboarding", False)
+    if not has_completed_onboarding() or force_onboarding:
         st.info(
             "🎉 머먹에 오신 것을 환영합니다! 맞춤 추천을 위한 간단한 설정을 진행해주세요."
         )
+        # 강제 온보딩인 경우 메시지 변경
+        if force_onboarding:
+            st.info(
+                "🔄 프로필을 다시 설정합니다. 더 정확한 추천을 위해 정보를 업데이트해주세요!"
+            )
+            # 강제 온보딩 플래그 리셋
+            st.session_state["force_onboarding"] = False
+
         # 온보딩에서도 app 인스턴스가 필요하므로 먼저 생성
         app = What2EatApp()
         onboarding_page = OnboardingPage(app)
@@ -361,10 +812,12 @@ def main():
     selected_page = render_authenticated_sidebar()
 
     # 온보딩 완료 직후 환영 메시지 표시
-    if ("selected_page_history" in st.session_state and 
-        len(st.session_state.selected_page_history) == 1 and 
-        selected_page == "🤤 오늘 머먹?" and 
-        has_completed_onboarding()):
+    if (
+        "selected_page_history" in st.session_state
+        and len(st.session_state.selected_page_history) == 1
+        and selected_page == "🤤 오늘 머먹?"
+        and has_completed_onboarding()
+    ):
         st.success("🎉 온보딩이 완료되었습니다! 이제 맞춤 추천을 받아보세요.")
 
     # 선택된 페이지에 따라 해당 함수 호출
@@ -372,8 +825,8 @@ def main():
         chat_page_fragment(page_manager)
     elif selected_page == "🕺🏽 니가 가본 그집":
         ranking_page_fragment(page_manager)
-    elif selected_page == "📊 내 활동 로그":
-        user_activity_logs_fragment()
+    elif selected_page == "👤 마이페이지":
+        my_page_fragment()
     elif selected_page == "⚽ 맛집 이상형 월드컵":
         worldcup_fragment(page_manager)
 

--- a/src/pages/onboarding.py
+++ b/src/pages/onboarding.py
@@ -46,10 +46,12 @@ class OnboardingPage:
                 if "diner_idx" in df.columns and "diner_name" in df.columns:
                     # 거리 정보가 있으면 포함, 없으면 기본 정보만
                     if "distance" in df.columns:
-                        basic_df = df[["diner_idx", "diner_name", "distance"]].dropna(subset=["diner_idx", "diner_name"])
+                        basic_df = df[["diner_idx", "diner_name", "distance"]].dropna(
+                            subset=["diner_idx", "diner_name"]
+                        )
                     else:
                         basic_df = df[["diner_idx", "diner_name"]].dropna()
-                    
+
                     search_engine = DinerSearchEngine()
                     search_engine.load_basic_data(basic_df)
                     st.session_state.search_engine = search_engine
@@ -88,13 +90,15 @@ class OnboardingPage:
                 jamo_threshold=0.9,
                 jamo_candidate_threshold=0.7,
             )
-            
+
             # 매칭 타입에 따라 다른 정렬 기준 적용
             if not results.empty:
                 if "jamo_score" in results.columns:
                     # 자모 매칭의 경우 점수 순으로 정렬
                     if "자모 매칭" in results["match_type"].values:
-                        results.sort_values(by="jamo_score", ascending=False, inplace=True)
+                        results.sort_values(
+                            by="jamo_score", ascending=False, inplace=True
+                        )
                     # 정확한 매칭이나 부분 매칭의 경우 거리 순으로 정렬 (거리 정보가 있는 경우)
                     elif "distance" in results.columns:
                         results.sort_values(by="distance", ascending=True, inplace=True)
@@ -107,13 +111,15 @@ class OnboardingPage:
                 # 검색 결과 표시 및 평가
                 for i, (_, row) in enumerate(results.iterrows(), 1):
                     with st.expander(f"🍽️ {i}. {row['name']} ({row['match_type']})"):
-                        st.markdown(f"**📍 [카카오맵에서 보기](https://place.map.kakao.com/{row['idx']})**")
+                        st.markdown(
+                            f"**📍 [카카오맵에서 보기](https://place.map.kakao.com/{row['idx']})**"
+                        )
                         st.markdown(f"**매칭 타입:** {row['match_type']}")
-                        
+
                         # 거리 정보 표시 (있는 경우)
                         if "distance" in row and pd.notna(row["distance"]):
                             st.markdown(f"**🚶‍♂️ 거리:** {row['distance']:.1f}km")
-                        
+
                         # 평가 섹션
                         st.markdown("---")
                         st.markdown("**⭐ 평가하기**")
@@ -125,7 +131,9 @@ class OnboardingPage:
 
                         # 이미 평가한 경우 수정 가능하도록 안내
                         if current_rating > 0:
-                            st.success(f"✅ 이미 {current_rating}점을 주셨습니다! (별점을 다시 클릭하면 수정할 수 있어요)")
+                            st.success(
+                                f"✅ 이미 {current_rating}점을 주셨습니다! (별점을 다시 클릭하면 수정할 수 있어요)"
+                            )
 
                         # st.feedback 사용 (수정 가능)
                         feedback = st.feedback(
@@ -138,8 +146,10 @@ class OnboardingPage:
                             if current_rating == 0:
                                 st.success(f"✅ {feedback}점을 주셨습니다!")
                             else:
-                                st.success(f"✅ 평가를 {feedback}점으로 수정하셨습니다!")
-                            
+                                st.success(
+                                    f"✅ 평가를 {feedback}점으로 수정하셨습니다!"
+                                )
+
                             st.session_state.restaurant_ratings[rating_key] = feedback
 
     def _handle_current_location(self):
@@ -616,19 +626,21 @@ class OnboardingPage:
 
         # 검색 기능 추가
         st.markdown("### 🔍 원하는 음식점을 검색해서 평가하기")
-        
+
         # 검색 안내 메시지
         st.info("""
         💡 **검색 팁!**
         - 현재 목록은 설정한 위치 주변의 음식점들만 보여드려요
         - 검색을 통해 **원하는 음식점**을 찾아서 평가할 수 있어요 🎯
         """)
-        
+
         # 검색 버튼을 더 눈에 띄게 배치
         st.markdown("---")
         col1, col2, col3 = st.columns([1, 2, 1])
         with col2:
-            if st.button("🔍 음식점 검색하기", type="primary", use_container_width=True):
+            if st.button(
+                "🔍 음식점 검색하기", type="primary", use_container_width=True
+            ):
                 self.search_restaurant_dialog()
 
         st.markdown("---")
@@ -673,124 +685,125 @@ class OnboardingPage:
 
             with st.expander(f"🍽️ {restaurant['name']} - {category_badge}"):
                 # 이미지 제거하고 정보만 표시
-                    st.markdown(
-                        f"[{restaurant['name']}](https://place.map.kakao.com/{restaurant['id']})"
-                    )
-                    if is_preferred:
-                        st.markdown("**선호 카테고리**")
-                    st.markdown(f"📍 {restaurant['address']}")
-                    st.markdown(f"{category_badge}")
-                    # st.markdown(
-                    #     f"⭐ 평점: {restaurant['rating']} ({restaurant['review_count']}개 리뷰)"
-                    # )
-                    if restaurant.get("distance"):
-                        st.markdown(f"🚶‍♂️ 거리: {restaurant['distance']}km")
+                st.markdown(
+                    f"[{restaurant['name']}](https://place.map.kakao.com/{restaurant['id']})"
+                )
+                if is_preferred:
+                    st.markdown("**선호 카테고리**")
+                st.markdown(f"📍 {restaurant['address']}")
+                st.markdown(f"{category_badge}")
+                # st.markdown(
+                #     f"⭐ 평점: {restaurant['rating']} ({restaurant['review_count']}개 리뷰)"
+                # )
+                if restaurant.get("distance"):
+                    st.markdown(f"🚶‍♂️ 거리: {restaurant['distance']}km")
 
-                    # 평가 (st.feedback 사용)
-                    rating_key = f"rating_{restaurant['id']}"
+                # 평가 (st.feedback 사용)
+                rating_key = f"rating_{restaurant['id']}"
+                current_rating = st.session_state.restaurant_ratings.get(rating_key, 0)
+
+                # 이미 평가한 경우 수정 가능하도록 안내
+                if current_rating > 0:
+                    st.success(f"✅ {current_rating}점을 주셨습니다!")
+                    rated_count += 1
+
+                # st.feedback 사용 (수정 가능)
+                feedback = (
+                    st.feedback(
+                        options="stars",
+                        key=f"feedback_{restaurant['id']}_{i}",
+                    )
+                    + 1
+                )
+
+                # 새로 평가하거나 수정한 경우 처리
+                if feedback is not None:
+                    if current_rating == 0:
+                        st.success(f"✅ {feedback}점을 주셨습니다!")
+                        rated_count += 1
+                    else:
+                        st.success(f"✅ 평가를 {feedback}점으로 수정하셨습니다!")
+
+                    st.session_state.restaurant_ratings[rating_key] = feedback
+
+                # 피드백 결과 처리
+                if feedback is not None:
+                    st.session_state.restaurant_ratings[rating_key] = feedback
+                    # st.rerun() 제거 - 성능 개선
+
+                    # 높은 점수를 준 음식점의 유사 음식점 표시
                     current_rating = st.session_state.restaurant_ratings.get(
                         rating_key, 0
                     )
-
-                    # 이미 평가한 경우 수정 가능하도록 안내
-                    if current_rating > 0:
-                        st.success(f"✅ {current_rating}점을 주셨습니다!")
-                        rated_count += 1
-                    
-                    # st.feedback 사용 (수정 가능)
-                    feedback = st.feedback(
-                        options="stars",
-                        key=f"feedback_{restaurant['id']}_{i}",
-                    ) + 1
-
-                    # 새로 평가하거나 수정한 경우 처리
-                    if feedback is not None:
-                        if current_rating == 0:
-                            st.success(f"✅ {feedback}점을 주셨습니다!")
-                            rated_count += 1
-                        else:
-                            st.success(f"✅ 평가를 {feedback}점으로 수정하셨습니다!")
-                        
-                        st.session_state.restaurant_ratings[rating_key] = feedback
-
-                    # 피드백 결과 처리
-                    if feedback is not None:
-                        st.session_state.restaurant_ratings[rating_key] = feedback
-                        # st.rerun() 제거 - 성능 개선
-
-                        # 높은 점수를 준 음식점의 유사 음식점 표시
-                        current_rating = st.session_state.restaurant_ratings.get(
-                            rating_key, 0
+                    if current_rating >= 4:
+                        st.success(
+                            f"👍 {current_rating}점! 비슷한 음식점도 함께 평가해보세요:"
                         )
-                        if current_rating >= 4:
-                            st.success(
-                                f"👍 {current_rating}점! 비슷한 음식점도 함께 평가해보세요:"
+                        similar_restaurants = (
+                            self.onboarding_manager.get_similar_restaurants(
+                                restaurant["id"]
                             )
-                            similar_restaurants = (
-                                self.onboarding_manager.get_similar_restaurants(
-                                    restaurant["id"]
-                                )
-                            )
+                        )
 
-                            for idx, similar in enumerate(similar_restaurants):
-                                # 유사 음식점 정보 표시
-                                with st.expander(
-                                    f"🔗 {similar['name']} - {similar['category']}",
-                                    expanded=False,
-                                ):
-                                    col1, col2 = st.columns([1, 2])
+                        for idx, similar in enumerate(similar_restaurants):
+                            # 유사 음식점 정보 표시
+                            with st.expander(
+                                f"🔗 {similar['name']} - {similar['category']}",
+                                expanded=False,
+                            ):
+                                col1, col2 = st.columns([1, 2])
 
-                                    with col1:
-                                        # 이미지 표시 (기본 이미지 사용)
-                                        st.image(
-                                            "https://via.placeholder.com/150x100/FF6B6B/FFFFFF?text=Restaurant",
-                                            width=150,
+                                with col1:
+                                    # 이미지 표시 (기본 이미지 사용)
+                                    st.image(
+                                        "https://via.placeholder.com/150x100/FF6B6B/FFFFFF?text=Restaurant",
+                                        width=150,
+                                    )
+
+                                with col2:
+                                    st.markdown(f"**{similar['name']}**")
+                                    st.markdown(f"🏷️ {similar['category']}")
+                                    if similar.get("distance"):
+                                        st.markdown(
+                                            f"🚶‍♂️ 거리: {similar['distance']}km"
                                         )
+                                    if similar.get("rating"):
+                                        st.markdown(f"⭐ 평점: {similar['rating']}")
 
-                                    with col2:
-                                        st.markdown(f"**{similar['name']}**")
-                                        st.markdown(f"🏷️ {similar['category']}")
-                                        if similar.get("distance"):
-                                            st.markdown(
-                                                f"🚶‍♂️ 거리: {similar['distance']}km"
-                                            )
-                                        if similar.get("rating"):
-                                            st.markdown(f"⭐ 평점: {similar['rating']}")
+                                    # 평가 키 생성
+                                    similar_key = f"rating_similar_{similar['id']}"
 
-                                        # 평가 키 생성
-                                        similar_key = f"rating_similar_{similar['id']}"
-
-                                        # 현재 평가 상태 표시
-                                        current_similar_rating = (
-                                            st.session_state.restaurant_ratings.get(
-                                                similar_key, 0
-                                            )
+                                    # 현재 평가 상태 표시
+                                    current_similar_rating = (
+                                        st.session_state.restaurant_ratings.get(
+                                            similar_key, 0
                                         )
-                                        if current_similar_rating > 0:
-                                            st.success(
-                                                f"✅ 이미 {current_similar_rating}점을 주셨습니다!"
-                                            )
-                                            rated_count += 1
-
-                                        # st.feedback 사용
-                                        similar_feedback = st.feedback(
-                                            options="stars",
-                                            key=f"feedback_similar_{similar['id']}_{restaurant['id']}_{idx}",
+                                    )
+                                    if current_similar_rating > 0:
+                                        st.success(
+                                            f"✅ 이미 {current_similar_rating}점을 주셨습니다!"
                                         )
+                                        rated_count += 1
 
-                                        if similar_feedback is not None:
-                                            # 새로 평가한 경우 즉시 표시
-                                            st.success(
-                                                f"✅ {similar_feedback}점을 주셨습니다!"
-                                            )
-                                            rated_count += 1
+                                    # st.feedback 사용
+                                    similar_feedback = st.feedback(
+                                        options="stars",
+                                        key=f"feedback_similar_{similar['id']}_{restaurant['id']}_{idx}",
+                                    )
 
-                                        # 피드백 결과 처리
-                                        if similar_feedback is not None:
-                                            st.session_state.restaurant_ratings[
-                                                similar_key
-                                            ] = similar_feedback
-                                            # st.rerun() 제거 - 성능 개선
+                                    if similar_feedback is not None:
+                                        # 새로 평가한 경우 즉시 표시
+                                        st.success(
+                                            f"✅ {similar_feedback}점을 주셨습니다!"
+                                        )
+                                        rated_count += 1
+
+                                    # 피드백 결과 처리
+                                    if similar_feedback is not None:
+                                        st.session_state.restaurant_ratings[
+                                            similar_key
+                                        ] = similar_feedback
+                                        # st.rerun() 제거 - 성능 개선
 
         # 더 많은 음식점 불러오기 버튼
         col1, col2, col3 = st.columns([1, 2, 1])

--- a/src/utils/auth.py
+++ b/src/utils/auth.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, Optional
 import firebase_admin
 import requests
 import streamlit as st
-from firebase_admin import auth
+from firebase_admin import auth, firestore
 
 from config.firebase_config import initialize_firebase_admin
 from utils.firebase_logger import get_firebase_logger
@@ -175,7 +175,7 @@ class FirebaseAuth:
         """비밀번호 재설정 이메일 전송"""
         try:
             # 사용자 존재 여부 확인
-            user = auth.get_user_by_email(email)
+            auth.get_user_by_email(email)
 
             # 비밀번호 재설정 링크 생성
             action_code_settings = auth.ActionCodeSettings(
@@ -208,175 +208,9 @@ class FirebaseAuth:
             return None
 
 
-# def google_auth_component():
-#     """Google 로그인을 위한 HTML/JavaScript 컴포넌트"""
-#     firebase_config = get_firebase_web_config()
-
-#     if not firebase_config.get("apiKey"):
-#         st.error("❌ Firebase 설정이 필요합니다.")
-#         return None
-
-#     html_code = f"""
-#     <!DOCTYPE html>
-#     <html>
-#     <head>
-#         <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-app-compat.js"></script>
-#         <script src="https://www.gstatic.com/firebasejs/9.23.0/firebase-auth-compat.js"></script>
-#         <style>
-#             .auth-container {{
-#                 max-width: 400px;
-#                 margin: 0 auto;
-#                 padding: 20px;
-#                 font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-#             }}
-
-#             .google-btn {{
-#                 width: 100%;
-#                 height: 50px;
-#                 background-color: #4285f4;
-#                 color: white;
-#                 border: none;
-#                 border-radius: 8px;
-#                 font-size: 16px;
-#                 font-weight: 500;
-#                 cursor: pointer;
-#                 display: flex;
-#                 align-items: center;
-#                 justify-content: center;
-#                 gap: 10px;
-#                 transition: all 0.2s ease;
-#                 margin-bottom: 10px;
-#             }}
-
-#             .google-btn:hover {{
-#                 background-color: #3367d6;
-#                 box-shadow: 0 2px 8px rgba(66, 133, 244, 0.3);
-#             }}
-
-#             .google-btn:disabled {{
-#                 background-color: #cccccc;
-#                 cursor: not-allowed;
-#             }}
-
-#             .error-message {{
-#                 color: #d93025;
-#                 font-size: 14px;
-#                 margin-top: 10px;
-#                 padding: 10px;
-#                 background-color: #fce8e6;
-#                 border-radius: 4px;
-#                 border-left: 3px solid #d93025;
-#             }}
-
-#             .success-message {{
-#                 color: #137333;
-#                 font-size: 14px;
-#                 margin-top: 10px;
-#                 padding: 10px;
-#                 background-color: #e6f4ea;
-#                 border-radius: 4px;
-#                 border-left: 3px solid #137333;
-#             }}
-#         </style>
-#     </head>
-#     <body>
-#         <div class="auth-container">
-#             <button id="google-signin-btn" class="google-btn">
-#                 <svg width="20" height="20" viewBox="0 0 24 24">
-#                     <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-#                     <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-#                     <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-#                     <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-#                 </svg>
-#                 Google로 로그인
-#             </button>
-#             <div id="message"></div>
-#         </div>
-
-#         <script>
-#             const firebaseConfig = {json.dumps(firebase_config)};
-
-#             // Firebase 초기화
-#             firebase.initializeApp(firebaseConfig);
-#             const auth = firebase.auth();
-
-#             // Google 로그인 버튼 이벤트
-#             document.getElementById('google-signin-btn').addEventListener('click', function() {{
-#                 const provider = new firebase.auth.GoogleAuthProvider();
-#                 provider.addScope('email');
-#                 provider.addScope('profile');
-
-#                 this.disabled = true;
-#                 this.textContent = '로그인 중...';
-
-#                 auth.signInWithPopup(provider)
-#                     .then((result) => {{
-#                         const user = result.user;
-#                         const userInfo = {{
-#                             uid: user.uid,
-#                             email: user.email,
-#                             displayName: user.displayName,
-#                             photoURL: user.photoURL,
-#                             emailVerified: user.emailVerified
-#                         }};
-
-#                         // Streamlit으로 사용자 정보 전달
-#                         window.parent.postMessage({{
-#                             type: 'GOOGLE_AUTH_SUCCESS',
-#                             user: userInfo,
-#                             idToken: result.credential.idToken
-#                         }}, '*');
-
-#                         document.getElementById('message').innerHTML =
-#                             '<div class="success-message">✅ 로그인 성공!</div>';
-#                     }})
-#                     .catch((error) => {{
-#                         console.error('로그인 오류:', error);
-#                         document.getElementById('message').innerHTML =
-#                             '<div class="error-message">❌ 로그인 실패: ' + error.message + '</div>';
-
-#                         this.disabled = false;
-#                         this.innerHTML = `
-#                             <svg width="20" height="20" viewBox="0 0 24 24">
-#                                 <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-#                                 <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-#                                 <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-#                                 <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-#                             </svg>
-#                             Google로 로그인
-#                         `;
-#                     }});
-#             }});
-
-#             // 메시지 리스너 (Streamlit으로부터)
-#             window.addEventListener('message', function(event) {{
-#                 if (event.data.type === 'RESET_GOOGLE_AUTH') {{
-#                     const btn = document.getElementById('google-signin-btn');
-#                     btn.disabled = false;
-#                     btn.innerHTML = `
-#                         <svg width="20" height="20" viewBox="0 0 24 24">
-#                             <path fill="currentColor" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"/>
-#                             <path fill="currentColor" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/>
-#                             <path fill="currentColor" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/>
-#                             <path fill="currentColor" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/>
-#                         </svg>
-#                         Google로 로그인
-#                     `;
-#                     document.getElementById('message').innerHTML = '';
-#                 }}
-#             }});
-#         </script>
-#     </body>
-#     </html>
-#     """
-
-#     return components.html(html_code, height=150)
-
-
 def auth_form():
     """통합 인증 폼 (로그인/회원가입/비밀번호 재설정)"""
     firebase_auth = FirebaseAuth()
-    session_manager = get_session_manager()
 
     if not firebase_auth.is_available():
         st.error("❌ Firebase Authentication이 설정되지 않았습니다.")
@@ -551,3 +385,190 @@ def require_auth(func):
         return func(*args, **kwargs)
 
     return wrapper
+
+
+def get_user_profile_from_firestore(uid: str = None) -> Optional[Dict[str, Any]]:
+    """Firestore에서 사용자 프로필 데이터를 조회"""
+    try:
+        # uid가 제공되지 않은 경우 현재 로그인된 사용자의 uid 사용
+        if uid is None:
+            user_info = get_current_user()
+            if not user_info:
+                return None
+            uid = user_info.get("localId")
+            if not uid:
+                return None
+
+        # Firebase Admin SDK가 초기화되었는지 확인
+        try:
+            firebase_admin.get_app()
+        except ValueError:
+            # Firebase Admin SDK 초기화
+            if not initialize_firebase_admin():
+                st.error("❌ Firebase Admin SDK 초기화에 실패했습니다.")
+                return None
+
+        db = firestore.client()
+
+        # onboarding_logs/profile 문서에서 직접 프로필 데이터 조회
+        profile_doc = (
+            db.collection("users")
+            .document(uid)
+            .collection("onboarding_logs")
+            .document("profile")
+            .get()
+        )
+
+        if profile_doc.exists:
+            return profile_doc.to_dict()
+
+        return None
+
+    except Exception as e:
+        st.error(f"❌ 프로필 데이터 조회 중 오류가 발생했습니다: {str(e)}")
+        return None
+
+
+def organize_user_profile_data(profile_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Firestore에서 가져온 프로필 데이터를 정리하는 헬퍼 함수"""
+    if not profile_data:
+        return {}
+
+    try:
+        # 직접 저장된 프로필 데이터 (detail 래핑 없음)
+        organized_data = {
+            # 기본 정보
+            "basic_info": {
+                "age": profile_data.get("birth_year"),
+                "gender": profile_data.get("gender"),
+                "user_id": profile_data.get("user_id"),
+                "created_at": profile_data.get("created_at"),
+                "updated_at": profile_data.get("updated_at"),
+                "onboarding_version": profile_data.get("onboarding_version", "1.0"),
+            },
+            # 예산 정보
+            "budget_info": {
+                "regular_budget": profile_data.get("regular_budget"),
+                "special_budget": profile_data.get("special_budget"),
+            },
+            # 맵기 정보
+            "spice_level": profile_data.get("spice_level"),
+            # 식사 동반자 정보
+            "dining_companions": profile_data.get("dining_companions", []),
+            # 못 먹는 것들
+            "dislikes": profile_data.get("dislikes", []),
+            # 알러지 정보
+            "allergies": profile_data.get("allergies", []),
+            # 선호 카테고리 (대분류)
+            "food_preferences_large": profile_data.get("food_preferences_large", []),
+            # 선호 카테고리 (중분류) - 기존 호환성
+            "food_preferences": profile_data.get("food_preferences", []),
+            # 평점 정보
+            "ratings": profile_data.get("ratings", {}),
+            # 메타 정보
+            "metadata": {
+                "created_at": profile_data.get("created_at"),
+                "updated_at": profile_data.get("updated_at"),
+                "onboarding_version": profile_data.get("onboarding_version"),
+            },
+        }
+
+        return organized_data
+
+    except Exception as e:
+        st.error(f"❌ 프로필 데이터 정리 중 오류가 발생했습니다: {str(e)}")
+        return {}
+
+
+def get_organized_user_profile(uid: str = None) -> Dict[str, Any]:
+    """사용자 프로필 데이터를 조회하고 정리해서 반환하는 통합 함수"""
+    profile_data = get_user_profile_from_firestore(uid)
+    if not profile_data:
+        return {}
+
+    return organize_user_profile_data(profile_data)
+
+
+def get_user_ratings_summary(uid: str = None) -> Dict[str, Any]:
+    """사용자 평점 정보를 요약해서 반환"""
+    try:
+        organized_profile = get_organized_user_profile(uid)
+        if not organized_profile:
+            return {}
+
+        ratings = organized_profile.get("ratings", {})
+        if not ratings:
+            return {
+                "total_rated": 0,
+                "average_rating": 0,
+                "rating_distribution": {},
+                "rated_restaurants": [],
+            }
+
+        # 평점 통계 계산
+        rated_restaurants = []
+        rating_values = []
+        rating_distribution = {"1": 0, "2": 0, "3": 0, "4": 0, "5": 0}
+
+        for restaurant_idx, rating in ratings.items():
+            if rating is not None:
+                diner_idx_str = restaurant_idx.split("_")[-1]
+                diner_idx = int(diner_idx_str)
+                rated_restaurants.append(
+                    {
+                        "diner_idx": diner_idx,
+                        "rating": rating,
+                    }
+                )
+                rating_values.append(rating)
+                rating_distribution[str(rating)] += 1
+
+        average_rating = sum(rating_values) / len(rating_values) if rating_values else 0
+
+        return {
+            "total_rated": len(rated_restaurants),
+            "average_rating": round(average_rating, 2),
+            "rating_distribution": rating_distribution,
+            "rated_restaurants": sorted(
+                rated_restaurants, key=lambda x: x.get("timestamp", ""), reverse=True
+            ),
+        }
+
+    except Exception as e:
+        st.error(f"❌ 평점 요약 생성 중 오류가 발생했습니다: {str(e)}")
+        return {}
+
+
+def get_user_preferences_summary(uid: str = None) -> Dict[str, Any]:
+    """사용자 선호도 정보를 요약해서 반환"""
+    try:
+        organized_profile = get_organized_user_profile(uid)
+        if not organized_profile:
+            return {}
+
+        return {
+            "spice_level": organized_profile.get("spice_level"),
+            "budget_range": {
+                "regular": organized_profile.get("budget_info", {}).get(
+                    "regular_budget"
+                ),
+                "special": organized_profile.get("budget_info", {}).get(
+                    "special_budget"
+                ),
+            },
+            "dining_companions": organized_profile.get("dining_companions", []),
+            "food_preferences_large": organized_profile.get(
+                "food_preferences_large", []
+            ),
+            "food_preferences": organized_profile.get("food_preferences", []),
+            "dislikes": organized_profile.get("dislikes", []),
+            "allergies": organized_profile.get("allergies", []),
+            "demographic": {
+                "age": organized_profile.get("basic_info", {}).get("age"),
+                "gender": organized_profile.get("basic_info", {}).get("gender"),
+            },
+        }
+
+    except Exception as e:
+        st.error(f"❌ 선호도 요약 생성 중 오류가 발생했습니다: {str(e)}")
+        return {}

--- a/src/utils/search_engine.py
+++ b/src/utils/search_engine.py
@@ -3,6 +3,7 @@
 """
 
 import logging
+
 import pandas as pd
 
 # 로거 설정
@@ -30,15 +31,12 @@ class DinerSearchEngine:
         self.diner_infos = []
 
         for _, row in df_basic.iterrows():
-            diner_info = {
-                "idx": str(row["diner_idx"]), 
-                "name": row["diner_name"]
-            }
-            
+            diner_info = {"idx": str(row["diner_idx"]), "name": row["diner_name"]}
+
             # 거리 정보가 있으면 추가
             if "distance" in row and pd.notna(row["distance"]):
                 diner_info["distance"] = float(row["distance"])
-            
+
             self.diner_infos.append(diner_info)
 
         logger.info(f"검색 엔진 초기화 완료: {len(self.diner_infos)}개 음식점")
@@ -69,7 +67,7 @@ class DinerSearchEngine:
         if exact_matches:
             results = pd.DataFrame(exact_matches).assign(
                 match_type="정확한 매칭",
-                jamo_score=1.0  # 정확한 매칭은 최고 점수
+                jamo_score=1.0,  # 정확한 매칭은 최고 점수
             )
             # 거리 정보가 있으면 거리 순으로 정렬
             if "distance" in results.columns:
@@ -83,7 +81,7 @@ class DinerSearchEngine:
         if partial_matches:
             results = pd.DataFrame(partial_matches).assign(
                 match_type="부분 매칭",
-                jamo_score=0.8  # 부분 매칭은 높은 점수
+                jamo_score=0.8,  # 부분 매칭은 높은 점수
             )
             # 거리 정보가 있으면 거리 순으로 정렬
             if "distance" in results.columns:
@@ -93,29 +91,31 @@ class DinerSearchEngine:
         # 3. 자모 기반 매칭
         jamo_candidates = []
         exact_jamo_match = None
-        
+
         for d in self.diner_infos:
             is_jamo, score = self._jamo_similarity(
                 norm_query, self._normalize(d["name"]), threshold=jamo_threshold
             )
-            
+
             if is_jamo:
                 # 정확한 자모 매칭 발견
                 exact_jamo_match = {
                     "name": d["name"],
                     "idx": d["idx"],
                     "jamo_score": score,
-                    "match_type": "자모 매칭"
+                    "match_type": "자모 매칭",
                 }
                 break
             elif score > jamo_candidate_threshold:
                 # 후보 자모 매칭 추가 (top_k개만 유지)
-                jamo_candidates.append({
-                    "name": d["name"],
-                    "idx": d["idx"],
-                    "jamo_score": score,
-                    "match_type": "자모 매칭"
-                })
+                jamo_candidates.append(
+                    {
+                        "name": d["name"],
+                        "idx": d["idx"],
+                        "jamo_score": score,
+                        "match_type": "자모 매칭",
+                    }
+                )
                 # 점수 순으로 정렬하고 top_k개만 유지
                 jamo_candidates.sort(key=lambda x: x["jamo_score"], reverse=True)
                 if len(jamo_candidates) > top_k:
@@ -125,17 +125,14 @@ class DinerSearchEngine:
         if exact_jamo_match:
             results = pd.DataFrame([exact_jamo_match])
             return self._add_kakao_map_links(results)
-        
+
         # 후보 자모 매칭이 있으면 반환
         if jamo_candidates:
             results = pd.DataFrame(jamo_candidates)
             return self._add_kakao_map_links(results)
-        
+
         # 검색 결과 없음
-        return pd.DataFrame().assign(
-            match_type="검색 결과 없음",
-            jamo_score=0.0
-        )
+        return pd.DataFrame().assign(match_type="검색 결과 없음", jamo_score=0.0)
 
     def _normalize(self, text: str) -> str:
         """
@@ -166,7 +163,7 @@ class DinerSearchEngine:
         a_jamo = " ".join(hangul_to_jamo(a))
         b_jamo = " ".join(hangul_to_jamo(b))
         score = fuzz.ratio(a_jamo, b_jamo) / 100.0  # 0-100을 0-1로 변환
-        
+
         if score > threshold:
             return True, score
         else:


### PR DESCRIPTION
#5 

- [What2Eat](https://github.com/lunch-corp/What2Eat/tree/feat/read-profile)/[src](https://github.com/lunch-corp/What2Eat/tree/feat/read-profile/src)/[utils](https://github.com/lunch-corp/What2Eat/tree/feat/read-profile/src/utils)
/auth.py 에서 get_user_profile_from_firestore로 호출하고 organize_user_profile_data로 파싱합니다.
- 구성한 김에 페이지 중에 로그 페이지를 마이 페이지 형식으로 변경했습니다.


- main.py와 pages.py 가 뚱뚱해져서 다음 번에 리팩토링으로 나누고 정리할게요!
